### PR TITLE
Fix code scanning alert no. 16: Flask app is run in debug mode

### DIFF
--- a/sec.py
+++ b/sec.py
@@ -11,4 +11,6 @@ def get_secret():
     return jsonify({"api_key": API_KEY}), 200
 
 if __name__ == '__main__':
-    app.run(debug=True)  # Enable debug mode for testing
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)  # Enable debug mode based on environment variable


### PR DESCRIPTION
Fixes [https://github.com/senseops/python_app/security/code-scanning/16](https://github.com/senseops/python_app/security/code-scanning/16)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Modify the `app.run()` method to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode.
2. Import the `os` module to access environment variables.
3. Update the `app.run()` call to use the value of the `FLASK_DEBUG` environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
