### PR TITLE
Fix code scanning alert no. 16: Flask app is run in debug mode

### DIFF
--- a/sec.py
+++ b/sec.py
@@ -14,4 +14,5 @@ def get_secret():
     return jsonify({"api_key": API_KEY}), 200
 
 if __name__ == '__main__':
-    app.run(debug=True)  # Enable debug mode for testing
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)  # Enable debug mode based on environment variable


### PR DESCRIPTION
Fixes [https://github.com/senseops/python_app/security/code-scanning/16](https://github.com/senseops/python_app/security/code-scanning/16)

To fix the problem, we should ensure that the Flask application does not run in debug mode in a production environment. A common approach is to use an environment variable to control the debug mode. This way, the application can run in debug mode during development but will have debug mode disabled in production.

- Modify the `app.run()` call to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode.
- Update the code to fetch the `FLASK_DEBUG` environment variable and use it to set the `debug` parameter in `app.run()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
