### PR TITLE
Fix code scanning alert no. 3: Uncontrolled command line

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,12 +28,20 @@ def hash_password():
     hashed = hashlib.sha1(password.encode()).hexdigest()
     return f"SHA-1 Hash: {hashed}"
 
+ALLOWED_COMMANDS = {
+    "date": ["date"],
+    "uptime": ["uptime"],
+    "whoami": ["whoami"]
+}
+
 @app.route('/command', methods=['POST'])
 def execute_command():
     command = request.form.get('command')
-    # Command injection vulnerability
-    output = subprocess.run(command, shell=True, capture_output=True, text=True)
-    return f"Command output: {output.stdout}"
+    if command in ALLOWED_COMMANDS:
+        output = subprocess.run(ALLOWED_COMMANDS[command], capture_output=True, text=True)
+        return f"Command output: {output.stdout}"
+    else:
+        return "Error: Command not allowed", 400
 
 @app.route('/greet', methods=['GET'])
 def greet_user():


### PR DESCRIPTION
Fixes [https://github.com/senseops/python_app/security/code-scanning/3](https://github.com/senseops/python_app/security/code-scanning/3)

To fix the problem, we should avoid passing user input directly to `subprocess.run` with `shell=True`. Instead, we can use a predefined allowlist of safe commands that the application is allowed to execute. This way, we can ensure that only known and safe commands are executed, mitigating the risk of command injection.

1. Define a dictionary of allowed commands.
2. Check if the user-provided command is in the allowlist.
3. If the command is in the allowlist, execute it using `subprocess.run` without `shell=True`.
4. If the command is not in the allowlist, return an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
